### PR TITLE
[mail] feat : 메일을 통한 인증 코드 발송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,14 @@ dependencies {
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // email sending (SMTP)
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.38.0'
 }
 
 dependencyManagement {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "name=redis"
       - "mode=standalone"
     restart: always
-    command: redis-server /user/local/conf/redis.conf"
+    command: redis-server /user/local/conf/redis.conf
   mysql:
     image: mysql:8.0
     container_name: mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,19 @@
 version: '3.8'
 
 services:
+  redis:
+    image: redis:latest
+    container_name: redis_test
+    ports:
+      - 6379:6379
+    volumes:
+      - ./redis/data:/data
+      - ./redis/conf/redis.conf:/user/local/conf/redis.conf
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    restart: always
+    command: redis-server /user/local/conf/redis.conf"
   mysql:
     image: mysql:8.0
     container_name: mysql

--- a/src/main/java/com/unionclass/memberservice/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/unionclass/memberservice/auth/application/AuthServiceImpl.java
@@ -9,7 +9,6 @@ import com.unionclass.memberservice.common.security.JwtProvider;
 import com.unionclass.memberservice.member.entity.Member;
 import com.unionclass.memberservice.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/unionclass/memberservice/auth/presentation/AuthController.java
+++ b/src/main/java/com/unionclass/memberservice/auth/presentation/AuthController.java
@@ -7,7 +7,9 @@ import com.unionclass.memberservice.auth.vo.in.SignInReqVo;
 import com.unionclass.memberservice.auth.vo.in.SignUpReqVo;
 import com.unionclass.memberservice.auth.vo.out.SignInResVo;
 import com.unionclass.memberservice.common.response.BaseResponseEntity;
+import com.unionclass.memberservice.common.response.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member-service/api/v1/auth")
+@Tag(name = "auth")
 public class AuthController {
 
     private final AuthService authService;
@@ -34,13 +37,13 @@ public class AuthController {
      * @param signUpReqVo
      * @return
      */
-    @Operation(summary = "회원가입", tags = {"auth"})
+    @Operation(summary = "회원가입")
     @PostMapping("/sign-up")
     public BaseResponseEntity<Void> signUp(
             @Valid @RequestBody SignUpReqVo signUpReqVo
     ) {
         authService.signUp(SignUpReqDto.from(signUpReqVo));
-        return new BaseResponseEntity<>("회원가입에 성공하였습니다.");
+        return new BaseResponseEntity<>(ResponseMessage.SIGN_UP_SUCCESS);
     }
 
     /**
@@ -48,13 +51,13 @@ public class AuthController {
      * @param signInReqVo
      * @return
      */
-    @Operation(summary = "로그인", tags = {"auth"})
+    @Operation(summary = "로그인")
     @PostMapping("/sign-in")
     public BaseResponseEntity<SignInResVo> signIn(
             @Valid @RequestBody SignInReqVo signInReqVo
     ) {
         return new BaseResponseEntity<>(
-                "로그인에 성공하였습니다.",
+                ResponseMessage.SIGN_IN_SUCCESS,
                 authService.signIn(SignInReqDto.from(signInReqVo)).toVo()
         );
     }

--- a/src/main/java/com/unionclass/memberservice/common/config/EmailConfig.java
+++ b/src/main/java/com/unionclass/memberservice/common/config/EmailConfig.java
@@ -1,0 +1,43 @@
+package com.unionclass.memberservice.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+    @Value("${spring.mail.address}")
+    private String address;
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(address);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+
+        return properties;
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/common/config/RedisConfig.java
+++ b/src/main/java/com/unionclass/memberservice/common/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.unionclass.memberservice.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/unionclass/memberservice/common/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorizeRequests -> authorizeRequests
                                 .requestMatchers(
-                                        "/member-service/api/v1/**",
+                                        "/member-service/api/v1/auth/**",
+                                        "/member-service/api/v1/email/**",
                                         "/swagger-ui/**",
                                         "/swagger-ui.html",
                                         "/v3/api-docs/**",

--- a/src/main/java/com/unionclass/memberservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/unionclass/memberservice/common/exception/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
     // member : 1100 ~ 1199
     NO_EXIST_MEMBER(HttpStatus.NOT_FOUND, false, 1100, "해당 회원을 찾을 수 없습니다."),
     INVALID_GENDER_VALUE(HttpStatus.BAD_REQUEST, false, 1101, "유효하지 않은 성별 정보입니다."),
-    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, false, 1102, "유효하지 않은 유저 권한입니다.");
+    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, false, 1102, "유효하지 않은 유저 권한입니다."),
+    EMAIL_ENCODING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 1103, "시스템 문자 인코딩 오류로 메일을 보낼 수 없습니다."),
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 1104, "메일 서버 오류로 인해 전송에 실패했습니다.")
+    ;
 
     /**
      * 2000 : post service error

--- a/src/main/java/com/unionclass/memberservice/common/redis/RedisUtils.java
+++ b/src/main/java/com/unionclass/memberservice/common/redis/RedisUtils.java
@@ -1,0 +1,18 @@
+package com.unionclass.memberservice.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtils {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValueWithTTL(String key, Object value, long ttlSeconds, TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(key, value, ttlSeconds, timeUnit);
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/common/response/BaseResponseEntity.java
+++ b/src/main/java/com/unionclass/memberservice/common/response/BaseResponseEntity.java
@@ -2,14 +2,14 @@ package com.unionclass.memberservice.common.response;
 
 import org.springframework.http.HttpStatus;
 
-public record BaseResponseEntity<T>(HttpStatus httpStatus, boolean isSuccess, String message, int code, T result) {
+public record BaseResponseEntity<T>(HttpStatus httpStatus, boolean isSuccess, ResponseMessage responseMessage, int code, T result) {
 
-    public BaseResponseEntity(String message, T result) {
-        this(HttpStatus.OK, true, message, 200, result);
+    public BaseResponseEntity(ResponseMessage responseMessage, T result) {
+        this(HttpStatus.OK, true, responseMessage, 200, result);
     }
 
-    public BaseResponseEntity(String message) {
-        this(HttpStatus.OK, true, message, 200, null);
+    public BaseResponseEntity(ResponseMessage responseMessage) {
+        this(HttpStatus.OK, true, responseMessage, 200, null);
     }
 }
 

--- a/src/main/java/com/unionclass/memberservice/common/response/ResponseMessage.java
+++ b/src/main/java/com/unionclass/memberservice/common/response/ResponseMessage.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum ResponseMessage {
 
     SIGN_UP_SUCCESS("회원가입에 성공하였습니다."),
-    SIGN_IN_SUCCESS("로그인에 성공하였습니다.");
+    SIGN_IN_SUCCESS("로그인에 성공하였습니다."),
+    SEND_VERIFICATION_EMAIL_SUCCESS("이메일 인증 코드를 성공적으로 발송하였습니다.")
+    ;
 
     private final String message;
 

--- a/src/main/java/com/unionclass/memberservice/common/security/JwtProvider.java
+++ b/src/main/java/com/unionclass/memberservice/common/security/JwtProvider.java
@@ -13,8 +13,8 @@ import java.security.Key;
 import java.util.Date;
 import java.util.function.Function;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class JwtProvider {
 
     private final Environment env;

--- a/src/main/java/com/unionclass/memberservice/email/application/EmailService.java
+++ b/src/main/java/com/unionclass/memberservice/email/application/EmailService.java
@@ -1,0 +1,10 @@
+package com.unionclass.memberservice.email.application;
+
+import com.unionclass.memberservice.email.dto.in.EmailReqDto;
+import jakarta.mail.MessagingException;
+
+import java.io.UnsupportedEncodingException;
+
+public interface EmailService {
+    void sendVerificationCode(EmailReqDto emailReqDto) throws MessagingException, UnsupportedEncodingException;
+}

--- a/src/main/java/com/unionclass/memberservice/email/application/EmailServiceImpl.java
+++ b/src/main/java/com/unionclass/memberservice/email/application/EmailServiceImpl.java
@@ -1,0 +1,66 @@
+package com.unionclass.memberservice.email.application;
+
+import com.unionclass.memberservice.common.exception.BaseException;
+import com.unionclass.memberservice.common.exception.ErrorCode;
+import com.unionclass.memberservice.email.util.EmailTemplateProvider;
+import com.unionclass.memberservice.common.redis.RedisUtils;
+import com.unionclass.memberservice.email.dto.in.EmailReqDto;
+import com.unionclass.memberservice.email.util.EmailUtils;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final RedisUtils redisUtils;
+    private final EmailUtils emailUtils;
+    private final EmailTemplateProvider emailTemplateProvider;
+    private final JavaMailSender mailSender;
+
+    private static final String EMAIL_VERIFY_KEY_PREFIX = "verify:email:";
+    private static final String EMAIL_TITLE = "이메일 인증코드 발송 메일입니다.";
+    private static final long EMAIL_CODE_TTL = 5L;
+    private static final TimeUnit EMAIL_CODE_TTL_UNIT = TimeUnit.MINUTES;
+
+    /**
+     * /member-service/api/v1/email
+     *
+     * 1. 메일을 통한 인증 코드 발송
+     */
+
+    /**
+     * 1. 메일을 통한 인증 코드 발송
+     * @param emailReqDto
+     */
+    @Override
+    public void sendVerificationCode(EmailReqDto emailReqDto) {
+
+        String verificationCode = emailUtils.generateRandomCode();
+        redisUtils.setValueWithTTL(EMAIL_VERIFY_KEY_PREFIX + emailReqDto.getEmail(), verificationCode, EMAIL_CODE_TTL, EMAIL_CODE_TTL_UNIT);
+
+        try {
+            mailSender.send(
+                    emailUtils.createMessage(
+                            emailReqDto.getEmail(),
+                            EMAIL_TITLE,
+                            emailTemplateProvider.getVerificationCodeByEmailTemplate(verificationCode)
+                    )
+            );
+            log.info("이메일 인증코드 발송 성공 - 수신자: {}", emailReqDto.getEmail());
+        } catch (UnsupportedEncodingException e) {
+            log.error("인코딩 설정 오류: {}", e.getMessage(), e);
+            throw new BaseException(ErrorCode.EMAIL_ENCODING_ERROR);
+        } catch (MessagingException e) {
+            log.error("메일 전송 실패: {}", e.getMessage(), e);
+            throw new BaseException(ErrorCode.EMAIL_SEND_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/email/dto/in/EmailReqDto.java
+++ b/src/main/java/com/unionclass/memberservice/email/dto/in/EmailReqDto.java
@@ -1,0 +1,25 @@
+package com.unionclass.memberservice.email.dto.in;
+
+import com.unionclass.memberservice.email.vo.in.EmailReqVo;
+import jakarta.validation.Valid;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailReqDto {
+
+    private String email;
+
+    @Builder
+    public EmailReqDto(String email) {
+        this.email = email;
+    }
+
+    public static EmailReqDto from(@Valid EmailReqVo emailReqVo) {
+        return EmailReqDto.builder()
+                .email(emailReqVo.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/email/presentation/EmailController.java
+++ b/src/main/java/com/unionclass/memberservice/email/presentation/EmailController.java
@@ -1,0 +1,49 @@
+package com.unionclass.memberservice.email.presentation;
+
+import com.unionclass.memberservice.common.response.BaseResponseEntity;
+import com.unionclass.memberservice.common.response.ResponseMessage;
+import com.unionclass.memberservice.email.application.EmailService;
+import com.unionclass.memberservice.email.dto.in.EmailReqDto;
+import com.unionclass.memberservice.email.vo.in.EmailReqVo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.UnsupportedEncodingException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member-service/api/v1/email")
+@Tag(name = "auth")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    /**
+     * /member-service/api/v1/email
+     *
+     * 1. 메일을 통한 인증 코드 발송
+     */
+
+    /**
+     * 1. 메일을 통한 인증 코드 발송
+     * @param emailReqVo
+     * @return
+     * @throws MessagingException
+     * @throws UnsupportedEncodingException
+     */
+    @Operation(summary = "메일을 통한 인증코드 발송")
+    @PostMapping("/send-code")
+    public BaseResponseEntity<Void> sendVerificationCode(
+            @Valid @RequestBody EmailReqVo emailReqVo
+    ) throws MessagingException, UnsupportedEncodingException {
+        emailService.sendVerificationCode(EmailReqDto.from(emailReqVo));
+        return new BaseResponseEntity<>(ResponseMessage.SEND_VERIFICATION_EMAIL_SUCCESS);
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/email/util/EmailTemplateProvider.java
+++ b/src/main/java/com/unionclass/memberservice/email/util/EmailTemplateProvider.java
@@ -1,0 +1,13 @@
+package com.unionclass.memberservice.email.util;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailTemplateProvider {
+
+    public String getVerificationCodeByEmailTemplate(String verificationCode) {
+        return "안녕하세요. Pick And Learn 입니다.<br/><br/>" +
+                "인증코드를 보내드립니다.<br/><br/>" +
+                "인증코드: <b>" + verificationCode + "</b>";
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/email/util/EmailUtils.java
+++ b/src/main/java/com/unionclass/memberservice/email/util/EmailUtils.java
@@ -1,0 +1,41 @@
+package com.unionclass.memberservice.email.util;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+import java.security.SecureRandom;
+
+@Component
+@RequiredArgsConstructor
+public class EmailUtils {
+
+    @Value("${spring.mail.name}")
+    private String name;
+    @Value("${spring.mail.address}")
+    private String address;
+
+    private final JavaMailSender mailSender;
+
+    public String generateRandomCode() {
+        return String.valueOf(100000 + new SecureRandom().nextInt(900000));
+    }
+
+    public MimeMessage createMessage(
+            String recipient, String title, String content
+    ) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        message.setFrom(new InternetAddress(address, name));
+        message.setRecipients(Message.RecipientType.TO, recipient);
+        message.setSubject(title);
+        message.setText(content, "UTF-8", "html");
+
+        return message;
+    }
+}

--- a/src/main/java/com/unionclass/memberservice/email/vo/in/EmailReqVo.java
+++ b/src/main/java/com/unionclass/memberservice/email/vo/in/EmailReqVo.java
@@ -1,0 +1,11 @@
+package com.unionclass.memberservice.email.vo.in;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+
+@Getter
+public class EmailReqVo {
+
+    @Email(message = "올바른 이메일 형식으로 입력해주세요.")
+    private String email;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,3 +10,8 @@ spring:
       idle-timeout: 300000
       max-lifetime: 900000
       connection-timeout: 10000
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:3306/learn_run_db
+    url: jdbc:mysql://${MYSQL_HOST}:3306/learn_run_member
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -10,3 +10,8 @@ spring:
       idle-timeout: 300000
       max-lifetime: 900000
       connection-timeout: 10000
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,14 @@ spring:
   application:
     name: member-service
   profiles:
-    active: prod
+    active: dev
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    name: ${MAIL_SENDER_NAME}
+    address: ${MAIL_SENDER_ADDRESS}
+    password: ${MAIL_APP_PASSWORD}
 
   jpa:
     hibernate:

--- a/src/main/resources/templates/email/code-verification.html
+++ b/src/main/resources/templates/email/code-verification.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
# 🚀 What type of PR is this?

> 괄호안에 x를 작성하면 체크 상태가 됩니다. Preview를 보시고 제대로 적용되었는지 확인해주세요.
> ex) [x] -> O [ x], [ x ], [x ] -> X -->

- [x] ✨ New Features (새로운 기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [ ] 🛠️ Refactoring (리팩토링)
- [ ] 📝 Documentation Update (문서 수정)
- [ ] 🚀 Performance Improvement (성능 개선)
- [ ] ⚡ ETC (기타 - 이곳에 작성해주세요)
- [ ] ⏳ test (테스트)

# 🔗 Related Issue 

> 해결하는 이슈 번호를 입력하면 PR이 머지될 때 자동으로 해당 이슈가 닫힙니다.
> ex) Closes #이슈번호 or Fixes #이슈번호 or Resolves #이슈번호

- #3 

## 💡 Description

> 변경된 내용을 설명해주세요.

## 1️⃣ Gmail 앱 비밀번호 설정

- Google 계정 관리에 접속한 후 보안 탭에서 2단계 인증으로 접근
- 2단계 인증을 위한 전화번호 추가, 인증번호 입력 후 인증을 완료
- 다시 Google 계정 관리로 돌아와서 아래와 같이 검색창에 앱 비밀번호를 입력하고 검색해야 함
- 앱 이름을 입력하고 생성된 앱 비밀번호를 저장해두도록 함

<aside>

🚩 화면을 닫은 이후에는 앱 비밀번호를 찾을 수 있는 방법이 없기 때문에 반드시 메모해두도록 함

</aside>

## 2️⃣ dependency 추가

- build.gradle
    
    ```bash
    dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-mail'
    }
    ```

## 3️⃣ yml 설정

- application.yml
    
    
    ```yaml
    spring:
      mail:
        host: smtp.gmail.com
        port: 587
        name: ${MAIL_SENDER_NAME}
        address: ${MAIL_SENDER_ADDRESS}
        password: ${MAIL_APP_PASSWORD}
    ```
    
    - host : Gmail SMTP 서버 주소 (고정값)
    - port : STARTTLS 방식 사용 시 포트 번호 587
    - name : 송신자 이름
    - address : 메일을 발송하는 실제 Gmail 주소
    - password : 해당 주소에 대한 앱 비밀번호
    
    [Reference 1] SSL 방식 (포트 465)
    
    ```yaml
    spring:
      mail:
        smtp:
          host: "smtp.gmail.com"
          address: "인증코드를 발송하는 이메일 주소"
          personal: "인증코드를 발송하는 송신인명"
          username: "구글ID"
          password: "발급받은 앱 비밀번호"
          port: 465
    ```
    
    ✅ 설명
    
    - 포트 465 는 SSL(Secure Sockets Layer) 기반의 SMTP 통신임
    - JavaMail 에서 SSL 을 사용하는 경우, 추가 속성 설정이 필요할 수 있음
    - address / personal 은 송신자 이름 표시 용도
    
    :주의-삼각-이미지-로고: 문제점
    
    - Spring Boot 에서는 기본적으로 TLS 기반의 587 포트 사용을 권장
    - mail.smtp.auth 나 starttls.enable 설정이 없어 기본 인증 설정이 누락될 가능성이 있음
    - 이 설정은 Spring 에서 바로 인식되기 어렵고, 추가 설정 코드가 필요할 수 있음
    
    [Reference 2] TLS(STARTTLS) 방식 (권장)
    
    ```yaml
    spring:
      mail:
        host: smtp.gmail.com
        port: 587
        username: ${MAIL_USERNAME}
        password: ${MAIL_APP_PASSWORD}
        properties:
          mail.smtp.auth: true
          mail.smtp.starttls.enable: true
    ```
    
    <aside>
    
    MAIL_USERNAME : 이메일을 전송할 주체의 이메일 주소 (host mail)
    
    APP_PASSWORD : 해당 계정으로 발급받은 App password
    
    </aside>
    
    ✅ 설명
    
    - 587번 포트는 STARTTLS (TLS로 업그레이드) 방식
    - mail.smtp.auth: true
        - 인증 필요함을 명시
    - mail.smtp.starttls.enable: true
        - TLS 암호화를 사용하겠다는 의미
    
    👍 장점
    
    - Spring Boot 표준 구성에 부합
    - 가장 호환성이 높고, 에러가 적은 설정
    - Gmail 에서도 공식적으로 권장하는 방식
    
    📌 팁
    
    - Spring boot 의 spring.mail.* 설정과 바로 매핑 가능
    
    [Reference 3] TLS 방식 + sslTrust 명시
    
    ```yaml
    spring:
      mail:
        host: smtp.gmail.com
        port: 587
        username: ${MAIL_USERNAME}
        password: ${MAIL_PASSWORD}
        properties:
        auth: true
        starttls: true
        sslTrust: smtp.gmail.com
    ```
    
    ✅ 설명
    
    - 위 설정도 STARTTLS 기반의 587 포트 사용
    - auth, starttls 는 Spring Boot 에서 속성명 규격이 맞지 않아 무시될 수 있음
    - sslTrust 는 보안 인증서에 대한 신뢰 호스트 지정
    
    :주의-삼각-이미지-로고: 주의
    
    - auth, starttls
        - 정확한 키는 mail.smtp.auth, mail.smtp.starttls.enable
        - 설정 자체는 맞는 의도지만 키 이름 오류로 작동하지 않을 가능성이 있음
    
    📌 팁
    
    - Spring Boot 에서는 속성 이름이 정확히 맞아야 적용되므로 주의가 필요함

## 4️⃣ property 설정 ⇒ binding 되지 않아서 우선 사용하지 않기로 결정

- EmailProperties

    ```java
    import lombok.Getter;
    import org.springframework.boot.context.properties.ConfigurationProperties;
    import org.springframework.boot.context.properties.bind.ConstructorBinding;
    
    @Getter
    @ConfigurationProperties(prefix = "email")
    public class EmailProperties {
    
        private final String host;
        private final int port;
        private final String name;
        private final String address;
        private final String password;
    
        @ConstructorBinding
        public EmailProperties(String host, int port, String name, String address, String password) {
            this.host = host;
            this.port = port;
            this.name = name;
            this.address = address;
            this.password = password;
        }
    }
    ```
    
    - @ConfigurationProperties(prefix = “email”)
        - application.yml 의 email.* 키를 자동 매핑
    - @ConstructorBinding
        - 생성자 바인딩
        - 객체를 변경 불가능한 (immutable) 상태로 설계할 수 있도록 도와준다.
            1. 모든 필드를 private final 로 선언
            3. setter 메서드를 만들지 않음
            4. 생성자에서만 값이 설정됨
    
- Main Application 에서 @ConfigurationPropertiesScan 추가
    
    ```java
    import org.springframework.boot.SpringApplication;
    import org.springframework.boot.autoconfigure.SpringBootApplication;
    import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
    import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
    import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
    
    @SpringBootApplication
    @EnableJpaAuditing
    @EnableDiscoveryClient
    @ConfigurationPropertiesScan
    public class MemberServiceApplication {
    
        public static void main(String[] args) {
            SpringApplication.run(MemberServiceApplication.class, args);
        }
    
    }
    ```
    
    - @ConfigurationPropertiesScan
        - @ConfigurationProperties 애노테이션이 붙은 클래스를 자동으로 감지하여 스프링 빈으로 등록하는 애노테이션
    
- EmailConfig 에서 @EnableConfigurationProperties(EmailProperties.class) 추가
    
    ```java
    import com.unionclass.memberservice.common.property.EmailProperties;
    import lombok.RequiredArgsConstructor;
    import org.springframework.boot.context.properties.EnableConfigurationProperties;
    import org.springframework.context.annotation.Bean;
    import org.springframework.context.annotation.Configuration;
    import org.springframework.mail.javamail.JavaMailSender;
    import org.springframework.mail.javamail.JavaMailSenderImpl;
    
    import java.util.Properties;
    
    @Configuration
    @RequiredArgsConstructor
    @EnableConfigurationProperties(EmailProperties.class)
    public class EmailConfig {
    
        private final EmailProperties emailProperties;
    
        @Bean
        public JavaMailSender javaMailSender() {
            JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
            javaMailSender.setHost(emailProperties.getHost());
            javaMailSender.setPort(emailProperties.getPort());
            javaMailSender.setUsername(emailProperties.getName());
            javaMailSender.setPassword(emailProperties.getPassword());
            javaMailSender.setJavaMailProperties(getMailProperties());
            javaMailSender.setDefaultEncoding("UTF-8");
    
            return javaMailSender;
        }
    
        private Properties getMailProperties() {
            Properties properties = new Properties();
            properties.setProperty("mail.smtp.auth", "true");
            properties.setProperty("mail.smtp.starttls.enable", "true");
    
            return properties;
        }
    }
    ```
    
    - @ConfigurationProperties 로 선언한 클래스가 자동으로 스프링 빈으로 등록되려면, 등록 시점을 스프링에게 알려줘야 함
    - 그 역할을 해주는게 @EnableConfigurationProperties

## 5️⃣ config 설정

- EmailConfig
    
    
    ```java
    import org.springframework.beans.factory.annotation.Value;
    import org.springframework.context.annotation.Bean;
    import org.springframework.context.annotation.Configuration;
    import org.springframework.mail.javamail.JavaMailSender;
    import org.springframework.mail.javamail.JavaMailSenderImpl;
    
    import java.util.Properties;
    
    @Configuration
    public class EmailConfig {
    
        @Value("${spring.mail.host}")
        private String host;
        @Value("${spring.mail.port}")
        private int port;
        @Value("${spring.mail.address}")
        private String address;
        @Value("${spring.mail.password}")
        private String password;
    
        @Bean
        public JavaMailSender javaMailSender() {
            JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
            javaMailSender.setHost(host);
            javaMailSender.setPort(port);
            javaMailSender.setUsername(address);
            javaMailSender.setPassword(password);
            javaMailSender.setJavaMailProperties(getMailProperties());
            javaMailSender.setDefaultEncoding("UTF-8");
    
            return javaMailSender;
        }
    
        private Properties getMailProperties() {
            Properties properties = new Properties();
            properties.setProperty("mail.smtp.auth", "true");
            properties.setProperty("mail.smtp.starttls.enable", "true");
    
            return properties;
        }
    }
    ```
    
    - @Configuration
        - 해당 클래스가 스프링 설정 클래스임을 나타냄
        - 이 클래스 내 @Bean 메서드가 스프링 컨테이너에 등록됨
    - @EnableConfigurationProperties(EmailProperties.class)
        - @ConfigurationProperties 로 선언한 클래스가 자동으로 스프링 빈으로 등록되려면, 등록 시점을 스프링에게 알려줘야 함
        - 그 역할을 해주는게 @EnableConfigurationProperties
    - 주요 메서드
        - javaMailSender()
            
            ```java
                @Bean
                public JavaMailSender javaMailSender() {
                    JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
                    javaMailSender.setHost(emailProperties.getHost());
                    javaMailSender.setPort(emailProperties.getPort());
                    javaMailSender.setUsername(emailProperties.getName());
                    javaMailSender.setPassword(emailProperties.getPassword());
                    javaMailSender.setJavaMailProperties(getMailProperties());
                    javaMailSender.setDefaultEncoding("UTF-8");
            
                    return javaMailSender;
                }
            ```
            
            ✅ JavaMailSenderImpl 을 생성하고, 아래와 같은 설정을 적용
            ✅ Bean 으로 등록됨
            
        - getMailProperties()
            
            ```java
                private Properties getMailProperties() {
                    Properties properties = new Properties();
                    properties.setProperty("mail.smtp.auth", "true");
                    properties.setProperty("mail.smtp.starttls.enable", "true");
            
                    return properties;
                }
            ```
            
            ✅ 메일 송수신에 필요한 추가 속성들을 설정
            

## 6️⃣ EmailServiceImpl 구현

- void sendVerificationCode(EmailReqDto emailReqDto);
    
    ```java
    import com.unionclass.memberservice.common.exception.BaseException;
    import com.unionclass.memberservice.common.exception.ErrorCode;
    import com.unionclass.memberservice.email.util.EmailTemplateProvider;
    import com.unionclass.memberservice.common.redis.RedisUtils;
    import com.unionclass.memberservice.email.dto.in.EmailReqDto;
    import com.unionclass.memberservice.email.util.EmailUtils;
    import jakarta.mail.MessagingException;
    import lombok.RequiredArgsConstructor;
    import lombok.extern.slf4j.Slf4j;
    import org.springframework.mail.javamail.JavaMailSender;
    import org.springframework.stereotype.Service;
    
    import java.io.UnsupportedEncodingException;
    import java.util.concurrent.TimeUnit;
    
    @Slf4j
    @Service
    @RequiredArgsConstructor
    public class EmailServiceImpl implements EmailService {
    
        private final RedisUtils redisUtils;
        private final EmailUtils emailUtils;
        private final EmailTemplateProvider emailTemplateProvider;
        private final JavaMailSender mailSender;
    
        private static final String EMAIL_VERIFY_KEY_PREFIX = "verify:email:";
        private static final String EMAIL_TITLE = "이메일 인증코드 발송 메일입니다.";
        private static final long EMAIL_CODE_TTL = 5L;
        private static final TimeUnit EMAIL_CODE_TTL_UNIT = TimeUnit.MINUTES;
    
        /**
         * /member-service/api/v1/email
         *
         * 1. 메일을 통한 인증 코드 발송
         */
    
        /**
         * 1. 메일을 통한 인증 코드 발송
         * @param emailReqDto
         */
        @Override
        public void sendVerificationCode(EmailReqDto emailReqDto) {
    
            String verificationCode = emailUtils.generateRandomCode();
            redisUtils.setValueWithTTL(EMAIL_VERIFY_KEY_PREFIX + emailReqDto.getEmail(), verificationCode, EMAIL_CODE_TTL, EMAIL_CODE_TTL_UNIT);
    
            try {
                mailSender.send(
                        emailUtils.createMessage(
                                emailReqDto.getEmail(),
                                EMAIL_TITLE,
                                emailTemplateProvider.getVerificationCodeByEmailTemplate(verificationCode)
                        )
                );
                [log.info](http://log.info/)("이메일 인증코드 발송 성공 - 수신자: {}", emailReqDto.getEmail());
            } catch (UnsupportedEncodingException e) {
                log.error("인코딩 설정 오류: {}", e.getMessage(), e);
                throw new BaseException(ErrorCode.EMAIL_ENCODING_ERROR);
            } catch (MessagingException e) {
                log.error("메일 전송 실패: {}", e.getMessage(), e);
                throw new BaseException(ErrorCode.EMAIL_SEND_FAIL);
            }
        }
    }
    ```
    
    ### 🎯 특징
    
    ✅ 책임 분리 및 모듈화
    
    - EmailUtils
    - EmailTemplateProvider
    - RedisUtils
    
    ✅ 상수 사용을 통한 의미 분리
    
    - 하드 코딩된 값 제거
    - 의미를 부여한 상수명을 사용해 가독성 및 변경 용이성 향상시킴 ⇒ 유지 보수 ⏫
    
    ✅ 예외 처리
    
    - try ~ catch 사용 : UnsupportedEncodingException, MessagingException
    
    ✅ 로그 처리
    
    - 성공(log.info) 및 실패(log.error) 시점을 정확하게 로그로 기록
    
    ### 📌 설명
    
    1. 인증 코드 6자리 생성
        - EmailUtils > generateRandomCode()
            
            
            ```java
            public String generateRandomCode() {
                    return String.valueOf(100000 + new SecureRandom().nextInt(900000));
                }
            ```
            
            - 0 이상 900000 미만 (0 ~ 899999) 사이의 정수 생성
            - 여기에 10000 을 더해서 최종적으로 100000 ~ 999999 사이의 숫자를 생성
            - 생성된 int 타입 숫자를 문자열로 변환하여 리턴
                - 메일이나 문자로 전송할 때는 문자열 형태가 필요하기 때문에 필수적인 처리임
                
    2. Redis 에 인증 코드 저장
        - RedisConfig > setValueWithTTL(String key, Object value, long ttlSeconds, TimeUnit timeUnit)
            
            
            ```java
                private final RedisTemplate<String, Object> redisTemplate;
            
                public void setValueWithTTL(String key, Object value, long ttlSeconds, TimeUnit timeUnit) {
                    redisTemplate.opsForValue().set(key, value, ttlSeconds, timeUnit);
                }
            ```
            
            - Redis 에 Key, Value 저장 및 TTL 설정
            
    3. 메세지 생성 및 전송
        - EmailTemplateProvider > getVerificationCodeByEmailTemplate(String verificationCode)
            
            
            ```java
                public String getVerificationCodeByEmailTemplate(String verificationCode) {
                    return "안녕하세요. Pick And Learn 입니다.<br/><br/>" +
                            "인증코드를 보내드립니다.<br/><br/>" +
                            "인증코드: <b>" + verificationCode + "</b>";
                }
            ```
            
        - EmailUtils > createMessage(String recipient, String title, String content)
            
            ```java
            import jakarta.mail.Message;
            import jakarta.mail.MessagingException;
            import jakarta.mail.internet.InternetAddress;
            import jakarta.mail.internet.MimeMessage;
            import lombok.RequiredArgsConstructor;
            import org.springframework.beans.factory.annotation.Value;
            import org.springframework.mail.javamail.JavaMailSender;
            import org.springframework.stereotype.Component;
            
            import java.io.UnsupportedEncodingException;
            import java.security.SecureRandom;
            
            @Component
            @RequiredArgsConstructor
            public class EmailUtils {
            
                @Value("${spring.mail.name}")
                private String name;
                @Value("${spring.mail.address}")
                private String address;
            
                private final JavaMailSender mailSender;
            
                public String generateRandomCode() {
                    return String.valueOf(100000 + new SecureRandom().nextInt(900000));
                }
            
                public MimeMessage createMessage(
                        String recipient, String title, String content
                ) throws MessagingException, UnsupportedEncodingException {
                    MimeMessage message = mailSender.createMimeMessage();
                    message.setFrom(new InternetAddress(address, name));
                    message.setRecipients(Message.RecipientType.TO, recipient);
                    message.setSubject(title);
                    message.setText(content, "UTF-8", "html");
            
                    return message;
                }
            }
            ```
            
            - MimeMessage 객체 생성
                
            - JavaMailSender 를 이용해 실제 전송할 이메일 메시지를 생성하고,
            발신자 정보, 수신자 이메일, 제목, 본문 콘텐츠 (HTML 포함) 등을 설정함
            - 예외 처리
                - MessagingException : 메시지 작성 실패 시 발생
                - UnsupportedEncodingException : 송신인 이름 인코딩 실패 시 발생
            - mailSender.createMimeMessage() : JavaMailSender 로 부터 빈 메세지 객체를 생성
            - message.setFrom(…) : 발신자 설정
                - emailProperties.getAddress() : 실제 송신 이메일 주소
                - emailProperties.getName() : 사용자에게 보여질 이름
                - 이 부분이 이메일 클라이언트 (Gmail) 에서 보낸 사람 으로 표시됨
            - message.setRecipients(…) : 수신자 이메일 주소 설정
            - message.setSubject(…) : 이메일 제목 설정
            - message.setText(… , “UTF-8” , “html”)
                - 본문 텍스트 설정
                - UTF-8 인코딩 사용
                - html 모드로 전송
        - JavaMailSender.send()
            - 내부적으로 SMTP 서버에 연결하여 메시지를 전송

## 📌 Changes

> 어떤 부분이 변경되었나요?

✅ dependency 추가
- build.gradle

✅ yml 설정
- application.yml

✅ config 설정
- EmailConfig

✅ EmailServiceImpl 구현
- void sendVerificationCode(EmailReqDto emailReqDto);

## 📸 Screenshot (선택 사항)

> 변경 사항을 보여주는 스크린샷을 첨부해주세요.

![image](https://github.com/user-attachments/assets/5f356186-8545-4cdc-ae99-f0fa9ffdc6a2)

![image](https://github.com/user-attachments/assets/f8dadf44-6464-4f41-a2fb-f815e1193878)

![image](https://github.com/user-attachments/assets/454da3b9-e322-45da-bc0d-c8f5c9fe6252)

## 🔗 Reference

> 참고할 만한 자료, 이슈 또는 관련 PR을 연결해주세요.

### 📝 정리 자료 (Notion)
- https://www.notion.so/1f902141a4b3801184afc8e6aded339d

### 📚 Reference
- https://hareandrabbit.tistory.com/entry/Spring-Gmail-SMTP%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%9D%B8%EC%A6%9D-%EA%B8%B0%EB%8A%A5-%EA%B0%9C%EB%B0%9C-with-Redis